### PR TITLE
Users can opt-in to source order nodes

### DIFF
--- a/plugin/gatsby-node.js
+++ b/plugin/gatsby-node.js
@@ -5,9 +5,18 @@ const { createInterface } = require("readline")
 const { finishLastOperation, createProductsOperation, createOrdersOperation, completedOperation } = require('./operations')
 const { nodeBuilder, idPattern } = require('./node-builder')
 
-const operations = [createProductsOperation, createOrdersOperation]
+module.exports.pluginOptionsSchema = ({ Joi }) => {
+  return Joi.object({
+    shopifyConnections: Joi.array().default([]).items(Joi.string().valid('orders'))
+  })
+}
 
-module.exports.sourceNodes = async function({ reporter, actions, createNodeId, createContentDigest }) {
+module.exports.sourceNodes = async function({ reporter, actions, createNodeId, createContentDigest }, pluginOptions) {
+  const operations = [createProductsOperation]
+  if (pluginOptions.shopifyConnections.includes('orders')) {
+    operations.push(createOrdersOperation)
+  }
+
   const nodeHelpers = createNodeHelpers({
     typePrefix: `Shopify`,
     createNodeId,

--- a/plugin/gatsby-node.js
+++ b/plugin/gatsby-node.js
@@ -2,8 +2,10 @@ require("dotenv").config()
 const fetch = require("node-fetch")
 const { createNodeHelpers } = require("gatsby-node-helpers")
 const { createInterface } = require("readline")
-const { finishLastOperation, createOperation, completedOperation } = require('./operations')
-const { nodeBuilder } = require('./node-builder')
+const { finishLastOperation, createProductsOperation, createOrdersOperation, completedOperation } = require('./operations')
+const { nodeBuilder, idPattern } = require('./node-builder')
+
+const operations = [createProductsOperation, createOrdersOperation]
 
 module.exports.sourceNodes = async function({ reporter, actions, createNodeId, createContentDigest }) {
   const nodeHelpers = createNodeHelpers({
@@ -12,42 +14,52 @@ module.exports.sourceNodes = async function({ reporter, actions, createNodeId, c
     createContentDigest,
   })
 
-  await finishLastOperation()
+  for await (const op of operations) {
+    await finishLastOperation()
 
-  const { bulkOperationRunQuery: { userErrors, bulkOperation} } = await createOperation()
+    const { bulkOperationRunQuery: { userErrors, bulkOperation} } = await op()
 
-  if (userErrors.length) {
-    reporter.panic({
-      context: {
-        sourceMessage: `Couldn't perform bulk operation`
-      }
-    }, ...userErrors)
+    if (userErrors.length) {
+      reporter.panic({
+        context: {
+          sourceMessage: `Couldn't perform bulk operation`
+        }
+      }, ...userErrors)
+    }
+
+    let resp = await completedOperation(bulkOperation.id)
+
+    const results = await fetch(resp.node.url)
+
+    /* FIXME
+    * Getting warnings about this being experimental.
+    * We want to read the stream one line at a time, but let's make
+    * sure to do it in the recommended way.
+    */
+    const rl = createInterface({
+      input: results.body,
+      crlfDelay: Infinity,
+    })
+
+    const objects = []
+    for await (const line of rl) {
+      objects.push(JSON.parse(line))
+    }
+
+    for(var i = 0; i < objects.length; i++) {
+      const obj = objects[i]
+      const builder = nodeBuilder(nodeHelpers)
+      const node = builder.buildNode(obj)
+      actions.createNode(node)
+    }
   }
+}
 
-  let resp = await completedOperation(bulkOperation.id)
-
-  const results = await fetch(resp.node.url)
-
-  /* FIXME
-   * Getting warnings about this being experimental.
-   * We want to read the stream one line at a time, but let's make
-   * sure to do it in the recommended way.
-   */
-  const rl = createInterface({
-    input: results.body,
-    crlfDelay: Infinity,
-  })
-
-  const objects = []
-  for await (const line of rl) {
-    objects.push(JSON.parse(line))
-  }
-
-  for(var i = 0; i < objects.length; i++) {
-    const obj = objects[i]
-    const builder = nodeBuilder(nodeHelpers)
-    const node = builder.buildNode(obj)
-    actions.createNode(node)
+exports.onCreateNode = function({ node }) {
+  if (node.internal.type === `ShopifyLineItem` && node.product) {
+    const [_match, _type, shopifyId] = node.product.id.match(idPattern)
+    node.productId = shopifyId
+    delete node.product
   }
 }
 
@@ -70,11 +82,35 @@ exports.createSchemaCustomization = ({ actions }) => {
     type ShopifyProductVariantPricePair implements Node {
       productVariant: ShopifyProductVariant @link(from: "productVariantId", by: "shopifyId")
     }
+
+    type ShopifyOrder implements Node {
+      lineItems: [ShopifyLineItem]
+    }
+
+    type ShopifyLineItem implements Node {
+      product: ShopifyProduct @link(from: "productId", by: "shopifyId")
+    }
   `)
 }
 
 exports.createResolvers = ({ createResolvers }) => {
   createResolvers({
+    ShopifyOrder: {
+      lineItems: {
+        type: ["ShopifyLineItem"],
+        resolve(source, args, context, info) {
+          return context.nodeModel.runQuery({
+            query: {
+              filter: {
+                orderId: { eq: source.shopifyId }
+              }
+            },
+            type: "ShopifyLineItem",
+            firstOnly: false,
+          })
+        }
+      }
+    },
     ShopifyProductVariant: {
       presentmentPrices: {
         type: ["ShopifyProductVariantPricePair"],

--- a/plugin/node-builder.js
+++ b/plugin/node-builder.js
@@ -52,5 +52,6 @@ function nodeBuilder(nodeHelpers) {
 }
 
 module.exports =  {
-  nodeBuilder
+  nodeBuilder,
+  idPattern: pattern,
 }

--- a/plugin/operations.js
+++ b/plugin/operations.js
@@ -1,8 +1,16 @@
 const { client } = require("./client")
-const { OPERATION_STATUS_QUERY, OPERATION_BY_ID, CREATE_OPERATION } = require("./queries")
+const { OPERATION_STATUS_QUERY, OPERATION_BY_ID, CREATE_PRODUCTS_OPERATION, CREATE_ORDERS_OPERATION } = require("./queries")
 
-function createOperation() {
-  return client.request(CREATE_OPERATION)
+function createOperation(operationQuery) {
+  return client.request(operationQuery)
+}
+
+function createProductsOperation() {
+  return createOperation(CREATE_PRODUCTS_OPERATION)
+}
+
+function createOrdersOperation() {
+  return createOperation(CREATE_ORDERS_OPERATION)
 }
 
 function currentOperation() {
@@ -48,5 +56,6 @@ module.exports = {
   currentOperation,
   finishLastOperation,
   completedOperation,
-  createOperation,
+  createProductsOperation,
+  createOrdersOperation
 }

--- a/plugin/queries.js
+++ b/plugin/queries.js
@@ -31,62 +31,12 @@ query OPERATION_BY_ID($id: ID!) {
 }
 `
 
-module.exports.CREATE_OPERATION = `
-  mutation {
-    bulkOperationRunQuery(
-    query: """
-      {
-        products {
-          edges {
-            node {
-              id
-              title
-              handle
-              variants {
-                edges {
-                  node {
-                    id
-                    availableForSale
-                    compareAtPrice
-                    selectedOptions {
-                      name
-                      value
-                    }
-                    price
-                    metafields {
-                      edges {
-                        node {
-                          description
-                          id
-                          key
-                          namespace
-                          value
-                          valueType
-                        }
-                      }
-                    }
-                    presentmentPrices {
-                      edges {
-                        node {
-                          __typename
-                          price {
-                            amount
-                            currencyCode
-                          }
-                          compareAtPrice {
-                            amount
-                            currencyCode
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+function bulkOperationQuery(query) {
+  return `
+    mutation {
+      bulkOperationRunQuery(
+      query: """
+        ${query}
       """
     ) {
       bulkOperation {
@@ -99,4 +49,92 @@ module.exports.CREATE_OPERATION = `
       }
     }
   }
+  `
+}
+
+const ORDERS_QUERY = `
+{
+  orders {
+    edges {
+      node {
+        id
+        edited
+        closed
+        closedAt
+        refunds {
+          id
+          createdAt
+        }
+        lineItems {
+          edges {
+            node {
+              id
+              product {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
 `
+
+const PRODUCTS_QUERY = `
+{
+  products {
+    edges {
+      node {
+        id
+        title
+        handle
+        variants {
+          edges {
+            node {
+              id
+              availableForSale
+              compareAtPrice
+              selectedOptions {
+                name
+                value
+              }
+              price
+              metafields {
+                edges {
+                  node {
+                    description
+                    id
+                    key
+                    namespace
+                    value
+                    valueType
+                  }
+                }
+              }
+              presentmentPrices {
+                edges {
+                  node {
+                    __typename
+                    price {
+                      amount
+                      currencyCode
+                    }
+                    compareAtPrice {
+                      amount
+                      currencyCode
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`
+
+module.exports.CREATE_PRODUCTS_OPERATION = bulkOperationQuery(PRODUCTS_QUERY)
+module.exports.CREATE_ORDERS_OPERATION = bulkOperationQuery(ORDERS_QUERY)

--- a/test-site/package.json
+++ b/test-site/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "gatsby-config.js",
   "scripts": {
-    "start": "gatsby develop"
+    "start": "gatsby develop",
+    "start:debug": "node --nolazy node_modules/.bin/gatsby develop --inspect-brk"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Retrieving orders is slow and seems to be mostly unused. This adds the ability to download the orders and create the nodes, but users must opt-in via plugin options.